### PR TITLE
Added type-safe function for executing Python code directly in PyTHONK

### DIFF
--- a/pythonk/internal/lib/py.py
+++ b/pythonk/internal/lib/py.py
@@ -1,0 +1,15 @@
+from pythonk.internal.lib.internal_operation import InternalOperation
+
+from pythonk.internal.utils.str import StrUtils
+from pythonk.parser.internal.err_handling import ArgumentTypeError
+
+
+class PyEvalOperation(InternalOperation):
+
+    def run(self):
+        if StrUtils.is_valid(str(self.value.eval())):
+            return self.value.eval()[1:-1]
+        else:
+            raise ArgumentTypeError("Function argument does not accept type other than 'string'")
+
+    pass

--- a/pythonk/internal/utils/type_checker.py
+++ b/pythonk/internal/utils/type_checker.py
@@ -14,9 +14,9 @@ class TypeChecker:
     @classmethod
     def is_valid(cls, value) -> bool:
         if not re.compile(cls.regex).match(value):
-            return True
-        else:
             return False
+        else:
+            return True
         pass
 
     @classmethod
@@ -24,11 +24,11 @@ class TypeChecker:
         left = str(left)
         right = str(right)
         if cls.is_valid(left) and cls.is_valid(right):
-            return 'both'
+            return 'none'
         elif cls.is_valid(left) and not cls.is_valid(right):
-            return 'left'
-        elif not cls.is_valid(left) and cls.is_valid(right):
             return 'right'
+        elif not cls.is_valid(left) and cls.is_valid(right):
+            return 'left'
         else:
             return 'none'
         pass

--- a/pythonk/lexer/lib_token.py
+++ b/pythonk/lexer/lib_token.py
@@ -5,6 +5,7 @@ from pythonk.lexer.token.basic import BasicToken
 from pythonk.lexer.token.data_types import DataTypesToken
 from pythonk.lexer.token.log import LogToken
 from pythonk.lexer.token.math import MathToken
+from pythonk.lexer.token.py import PyToken
 
 
 def add_token_libs(token_libs: List[BaseToken]) -> dict:
@@ -15,4 +16,4 @@ def add_token_libs(token_libs: List[BaseToken]) -> dict:
     return token_libs_result
 
 
-lib_token = add_token_libs([BasicToken, DataTypesToken, LogToken, MathToken])
+lib_token = add_token_libs([BasicToken, DataTypesToken, LogToken, MathToken, PyToken])

--- a/pythonk/lexer/token/py.py
+++ b/pythonk/lexer/token/py.py
@@ -1,0 +1,5 @@
+from pythonk.lexer.token.base_token import BaseToken
+
+PyToken: BaseToken = BaseToken({
+    "PY_EVAL": r"pyeval"
+})

--- a/pythonk/parser/internal/err_handling.py
+++ b/pythonk/parser/internal/err_handling.py
@@ -15,3 +15,6 @@ class ErrorHandling(StandardLib):
 
 class ArithmeticOperationTypeError(Exception):
     pass
+
+class ArgumentTypeError(Exception):
+    pass

--- a/pythonk/parser/internal/py.py
+++ b/pythonk/parser/internal/py.py
@@ -1,0 +1,13 @@
+from pythonk.internal.lib.py import PyEvalOperation
+from pythonk.parser.internal.standard_lib import StandardLib
+
+
+class Py(StandardLib):
+
+    def load_grammar(self):
+        @self.parser.production("program : PY_EVAL OPEN_PAREN expression CLOSE_PAREN SEMICOLON")
+        def py_eval(p):
+            return PyEvalOperation(p[2])
+        pass
+
+    pass

--- a/pythonk/parser/parser.py
+++ b/pythonk/parser/parser.py
@@ -8,6 +8,7 @@ from pythonk.parser.internal.data_types import DataTypes
 from pythonk.parser.internal.err_handling import ErrorHandling
 from pythonk.parser.internal.log import Log
 from pythonk.parser.internal.math import Math
+from pythonk.parser.internal.py import Py
 
 
 class PythonkParser():
@@ -22,6 +23,7 @@ class PythonkParser():
         Math()
         DataTypes()
         ErrorHandling()
+        Py()
         
         pass
 


### PR DESCRIPTION
### Type-safe function for executing Python code

```
pyeval("import os")
pyeval("os.getcwd()")
```

This will transform into

```
import os
os.getcwd()
```

This function only accepts string as argument