### PR TITLE
Type checking for variable declaration, setter via type annotation!

### DIFF
--- a/pythonk/ast/types/base_type.py
+++ b/pythonk/ast/types/base_type.py
@@ -13,6 +13,9 @@ class BaseType(BaseBox):
     def get_value(self) -> any:
         return any(None)
 
+    def get_type_name(self) -> str:
+        return "any"
+
     def eval(self):
         return self.value
 

--- a/pythonk/ast/types/data_types.py
+++ b/pythonk/ast/types/data_types.py
@@ -1,14 +1,13 @@
-from typing import Any
-
-from rply.token import BaseBox
-
 from pythonk.ast.types.base_type import BaseType
 
 
 class Boolean(BaseType):
 
     def get_value(self) -> any:
-        return bool(self.value)
+        return self.value
+
+    def get_type_name(self) -> str:
+        return "bool"
 
     pass
 
@@ -18,6 +17,9 @@ class String(BaseType):
     def get_value(self) -> any:
         return f"\"{str(self.value)}\""
 
+    def get_type_name(self) -> str:
+        return "string"
+
     pass
 
 
@@ -26,6 +28,9 @@ class Number(BaseType):
     def get_value(self) -> any:
         return int(self.value)
 
+    def get_type_name(self) -> str:
+        return "int"
+
     pass
 
 
@@ -33,5 +38,8 @@ class ExAny(BaseType):
 
     def get_value(self) -> any:
         return any(self.value)
+
+    def get_type_name(self) -> str:
+        return "any"
 
     pass

--- a/pythonk/ast/utils/expect_type.py
+++ b/pythonk/ast/utils/expect_type.py
@@ -1,6 +1,7 @@
 from rply import Token
 
 from pythonk.ast.types.base_type import BaseType
+from pythonk.ast.types.data_types import ExAny
 
 
 class ExpectType:
@@ -16,7 +17,10 @@ class ExpectType:
 
     @staticmethod
     def get_exp_type(value: Token) -> str:
-        return type(value).__name__
+        if value is not ExAny:
+            return value.get_type_name()
+        else:
+            return "any"
 
     pass
 

--- a/pythonk/ast/variable.py
+++ b/pythonk/ast/variable.py
@@ -1,5 +1,7 @@
 from rply.token import BaseBox, Token
 
+from pythonk.ast.types.data_types import String
+from pythonk.ast.utils.expect_type import ExpectType
 from pythonk.compiler.compile_stream import CompileStream
 
 let_var_env: list[dict] = []
@@ -42,7 +44,12 @@ def check_clet_or_let(var_name: str) -> str:
 
     raise VariableError(f"Variable {var_name} was not defined")
 
-    pass
+def get_var_type(var_name: str) -> str:
+    for var in let_var_env:
+        if var["filename"] == CompileStream.get_compiling_file() and var["name"] == var_name:
+            return var["type"]
+
+    raise VariableError(f"Variable {var_name} was not defined")
 
 
 class VariableSetterOperation(BaseBox):
@@ -55,6 +62,9 @@ class VariableSetterOperation(BaseBox):
     def eval(self):
         if check_var_defined(self.var_name.value):
             if check_clet_or_let(self.var_name.value) == 'let':
+                type_name: str = get_var_type(self.var_name.value)
+                if not type_name == self.var_expression.get_type_name() and not type_name == "any":
+                    raise TypeError(f"{self.var_expression.get_type_name()} should not be assigned to {type_name}")
                 CompileStream.add_stream(f"{self.var_name.value} = {self.var_expression.value}")
             else:
                 raise AssignmentError("Constant(clet) variable cannot be reassigned")
@@ -66,6 +76,13 @@ class VariableSetterOperation(BaseBox):
 
 class VariableAssignmentOperation(BaseBox):
 
+    native_type_remap: dict = {
+        "any": "any",
+        "string": "str",
+        "int": "int",
+        "bool": "bool"
+    }
+
     def __init__(self, var_name: Token, var_expression: Token, const: bool = False, var_type: str = 'any'):
         self.var_name = var_name
         self.var_expression = var_expression
@@ -76,14 +93,22 @@ class VariableAssignmentOperation(BaseBox):
     def eval(self):
         var_name: str = self.var_name.value
         var_expression: str = self.var_expression.value
+        var_type: str = self.var_type
 
         # Variable was assigned to something and was found in vmm(variable memory map)
         if check_var_defined(var_name):
             raise AssignmentError(f"Variable {var_name} cannot be reassigned")
 
+        # Check if the given type annotation is in type remap
+        if var_type not in self.native_type_remap.keys():
+            raise TypeError(f"Type {var_type} is an unknown type")
+
+        if not var_type == self.var_expression.get_type_name() and not var_type == "any":
+            raise TypeError(f"{ExpectType.get_exp_type(self.var_expression)} should not be assigned to {var_type}")
+
         # Put variable into vmm so that we can find out if the variable was assigned later
         save_var(self.const, self.var_type, self.var_name.value)
-        CompileStream.add_stream(f"{var_name} = {var_expression}")
+        CompileStream.add_stream(f"{var_name}: {self.native_type_remap[var_type]} = {var_expression}")
         pass
 
     pass

--- a/pythonk/compiler/config.py
+++ b/pythonk/compiler/config.py
@@ -10,7 +10,15 @@ class CompilerConfig:
     @classmethod
     def init_config(cls, projectRoot: str):
         cls.projectRoot = os.path.abspath(projectRoot)
-        cls.config = json.load(open(os.path.join(cls.projectRoot, 'pykconfig.json')))
+        cls.config = cls.safe_load_config()
+
+    @classmethod
+    def safe_load_config(cls):
+        config_path: str = os.path.join(cls.projectRoot, 'pykconfig.json')
+        if not os.path.exists(config_path):
+            raise FileNotFoundError("pykconfig.json is not found, not proceeding to compile")
+
+        return json.load(open(config_path))
 
     @classmethod
     def get_config(cls) -> object:

--- a/pythonk/parser/internal/data_types.py
+++ b/pythonk/parser/internal/data_types.py
@@ -12,7 +12,15 @@ class DataTypes(StandardGrammar):
 
         @self.parser.production('const : BOOLEAN')
         def number(p):
-            return Boolean(p[0].getstr())
+            finalized_bool: str = ""
+            given_bool: str = p[0].getstr()
+
+            if given_bool == "false":
+                finalized_bool = "False"
+            elif given_bool == "true":
+                finalized_bool = "True"
+
+            return Boolean(finalized_bool)
 
         @self.parser.production('const : NUMBER')
         def number(p):

--- a/pythonk/parser/internal/variable.py
+++ b/pythonk/parser/internal/variable.py
@@ -1,3 +1,4 @@
+from pythonk.ast.utils.expect_type import ExpectType
 from pythonk.ast.variable import VariableAssignmentOperation, VariableGetterOperation, VariableSetterOperation
 from pythonk.parser.internal.standard_grammar import StandardGrammar
 
@@ -5,11 +6,6 @@ from pythonk.parser.internal.standard_grammar import StandardGrammar
 class Variable(StandardGrammar):
 
     def load_grammar(self):
-        # @self.parser.production("program : VAR_CLET VAR_IDENTIFIER = expression SEMICOLON")
-        # @self.parser.production("program : VAR_LET VAR_IDENTIFIER = expression SEMICOLON")
-        # def typed_var_define(p):
-        #     return
-
         @self.parser.production("program : VAR_CLET VAR_IDENTIFIER = expression SEMICOLON")
         @self.parser.production("program : VAR_LET VAR_IDENTIFIER = expression SEMICOLON")
         def var_define(p):
@@ -22,5 +18,10 @@ class Variable(StandardGrammar):
         @self.parser.production("program : VAR_IDENTIFIER = expression SEMICOLON")
         def var_set(p):
             return VariableSetterOperation(p[0], p[2])
+
+        @self.parser.production("program : VAR_CLET VAR_IDENTIFIER COLON expression = expression SEMICOLON")
+        @self.parser.production("program : VAR_LET VAR_IDENTIFIER COLON expression = expression SEMICOLON")
+        def typed_var_define(p):
+            return VariableAssignmentOperation(p[1], p[5], p[0].name == "VAR_CLET", p[3].value.value)
 
     pass


### PR DESCRIPTION
### New Features

- Simple type checking for variable declaration

  ```
  // Does not throw error
  let message: string = "hello";
  
  // Does throw error
  let wrongmsg: int = "hello";
  let wrongmsg: string = 1;
  ```

- Throws error when you attemp to set a variable with a different type

  ```
  let message: string = "hello";
  
  // Does not throw error
  message = "world";
  
  // Does throw error
  message = 1;
  ```

### Minor Changes

- Throws error when pykconfig.json is not found